### PR TITLE
Add friendly error message if we fail to resolve a query which looks like a resource name

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -116,7 +116,7 @@ func dashboardRun(cmd *cobra.Command, args []string) {
 	ctx = createSnapshotContext(ctx, dashboardName)
 
 	statushooks.SetStatus(ctx, "Initializing…")
-	initData := initialisation.NewInitData[*modconfig.Dashboard](ctx, "dashboard", dashboardName)
+	initData := initialisation.NewInitData[*modconfig.Dashboard](ctx, dashboardName)
 
 	if len(viper.GetStringSlice(constants.ArgExport)) > 0 {
 		err := initData.RegisterExporters(dashboardExporters()...)

--- a/internal/cmd/query.go
+++ b/internal/cmd/query.go
@@ -124,10 +124,6 @@ func queryRun(cmd *cobra.Command, args []string) {
 		error_helpers.FailOnError(err)
 	}
 
-	// if there are args, put them into viper for retrieval by the dashboard execution
-	if initData.QueryArgs != nil {
-		viper.Set(constants.ConfigKeyQueryArgs, initData.QueryArgs)
-	}
 	// execute query as a snapshot
 	snap, err := dashboardexecute.GenerateSnapshot(ctx, initData.WorkspaceEvents, initData.Target, nil)
 	if err != nil {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -55,7 +55,7 @@ func runServerCmd(cmd *cobra.Command, _ []string) {
 	}
 
 	// initialise the workspace
-	modInitData := initialisation.NewInitData[*modconfig.Dashboard](ctx, "dashboard")
+	modInitData := initialisation.NewInitData[*modconfig.Dashboard](ctx)
 	error_helpers.FailOnError(modInitData.Result.Error)
 
 	// ensure dashboard assets

--- a/internal/cmdconfig/cmd_type.go
+++ b/internal/cmdconfig/cmd_type.go
@@ -17,17 +17,20 @@ import (
 //   - if the command type is 'query', the target may be a query string rather than a resource name
 //     in this case, convert into a query and add to workspace (to allow for simple snapshot generation)
 func ResolveTarget[T modconfig.ModTreeItem](cmdArgs []string, w *workspace.Workspace) (T, error) {
-
 	var empty T
+	if len(cmdArgs) == 0 {
+		return empty, nil
+	}
 	if len(cmdArgs) > 1 {
 		return empty, sperr.New("only a single target is supported")
 	}
+	// now try to resolve
 	target, queryArgs, err := workspace.ResolveResourceAndArgsFromSQLString[T](cmdArgs[0], w)
 	if err != nil {
 		return empty, err
 	}
 
-	// if the command type is 'query', the target may be a query string rather than a resource name
+	// ok we managed to resolve
 
 	// now check if any args were specified on the command line using the --arg flag
 	// if so verify no args were passed in the resource invocation, e.g. query.my_query("val1","val1"

--- a/internal/initialisation/init_data.go
+++ b/internal/initialisation/init_data.go
@@ -29,7 +29,6 @@ type InitData[T modconfig.ModTreeItem] struct {
 	ShutdownTelemetry func()
 	ExportManager     *export.Manager
 	Target            T
-	QueryArgs         *modconfig.QueryArgs
 }
 
 func NewErrorInitData[T modconfig.ModTreeItem](err error) *InitData[T] {
@@ -150,16 +149,9 @@ func (i *InitData[T]) resolveTarget(args []string) {
 		return
 	}
 
-	// TODO KAI CHECK THIS
-	if target.Name() == "" {
-		i.Result.Error = sperr.New("no target found")
-		return
-	}
-
-	// we only expect a single target - this should be enforced by Cobra
-
+	// we only expect zero or one target (depending on command)  - this should be enforced by Cobra
 	i.Target = target
-	//i.QueryArgs = queryArgs[targets[0].GetUnqualifiedName()]
+
 }
 
 func validateModRequirementsRecursively(mod *modconfig.Mod) []string {


### PR DESCRIPTION
Fix query run error for non-snapshot output