### PR TITLE
Update JSON output. Closes #375

### DIFF
--- a/internal/dashboardtypes/leaf_data.go
+++ b/internal/dashboardtypes/leaf_data.go
@@ -2,6 +2,7 @@ package dashboardtypes
 
 import (
 	"github.com/turbot/pipe-fittings/queryresult"
+	"github.com/turbot/pipe-fittings/utils"
 	localqueryresult "github.com/turbot/powerpipe/internal/queryresult"
 )
 
@@ -16,11 +17,21 @@ func NewLeafData(result *localqueryresult.SyncQueryResult) *LeafData {
 		Columns: result.Cols,
 	}
 
+	// create a unique name generator
+	nameGenerator := utils.NewUniqueNameGenerator()
+
 	for rowIdx, row := range result.Rows {
 		rowData := make(map[string]interface{}, len(result.Cols))
 		for i, data := range row.(*localqueryresult.RowResult).Data {
+			// ensure column name is unique
 			columnName := leafData.Columns[i].Name
-			rowData[columnName] = data
+			uniqueName := nameGenerator.GetUniqueName(columnName)
+			if uniqueName != columnName {
+				// if the column name has changed, store the original
+				leafData.Columns[i].OriginalName = columnName
+				leafData.Columns[i].Name = uniqueName
+			}
+			rowData[uniqueName] = data
 		}
 
 		leafData.Rows[rowIdx] = rowData

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -21,7 +21,6 @@ import (
 	"github.com/turbot/pipe-fittings/cmdconfig"
 	"github.com/turbot/pipe-fittings/constants"
 	"github.com/turbot/pipe-fittings/error_helpers"
-	"github.com/turbot/pipe-fittings/utils"
 	"github.com/turbot/powerpipe/internal/queryresult"
 )
 
@@ -248,19 +247,15 @@ func displayJSON(ctx context.Context, result *queryresult.Result) int {
 		},
 	}
 
-	// create a unique name generator
-	nameGenerator := utils.NewUniqueNameGenerator()
+	//// create a unique name generator
+	//nameGenerator := utils.NewUniqueNameGenerator()
 
 	// add column defs to the JSON output
 	for _, col := range result.Cols {
 		c := columnDef{
-			Name:     nameGenerator.GetUniqueName(col.Name),
-			DataType: strings.ToLower(col.DataType),
-		}
-
-		// if the column name has changed, store the original
-		if c.Name != col.Name {
-			c.OriginalName = col.Name
+			Name:         col.Name,
+			OriginalName: col.OriginalName,
+			DataType:     strings.ToLower(col.DataType),
 		}
 		// add to the column def array
 		op.Columns = append(op.Columns, c)

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -240,38 +240,6 @@ type columnDef struct {
 	OriginalName string `json:"original_name,omitempty"`
 }
 
-type uniqueNameGenerator struct {
-	lookup map[string]struct{}
-}
-
-// ctor
-func newUniqueNameGenerator() *uniqueNameGenerator {
-	return &uniqueNameGenerator{
-		lookup: make(map[string]struct{}),
-	}
-}
-
-// getUniqueName returns a unique name based on the input name
-func (g *uniqueNameGenerator) getUniqueName(name string) string {
-	// ensure a unique column name
-	for {
-		// check the lookup to see if this name exists
-		if _, exists := g.lookup[name]; !exists {
-			// name is unique - we are done
-			break
-		}
-		// name is not unique - generate a new name
-		// store the original name
-		originalName := name
-
-		// generate a new name
-		name = fmt.Sprintf("%s_%s", originalName, utils.RandomString(4))
-	}
-	// add the unique name into the lookup
-	g.lookup[name] = struct{}{}
-	return name
-}
-
 func displayJSON(ctx context.Context, result *queryresult.Result) int {
 	rowErrors := 0
 	var op = jsonOutput{
@@ -281,12 +249,12 @@ func displayJSON(ctx context.Context, result *queryresult.Result) int {
 	}
 
 	// create a unique name generator
-	nameGenerator := newUniqueNameGenerator()
+	nameGenerator := utils.NewUniqueNameGenerator()
 
 	// add column defs to the JSON output
 	for _, col := range result.Cols {
 		c := columnDef{
-			Name:     nameGenerator.getUniqueName(col.Name),
+			Name:     nameGenerator.GetUniqueName(col.Name),
 			DataType: strings.ToLower(col.DataType),
 		}
 

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -247,9 +247,6 @@ func displayJSON(ctx context.Context, result *queryresult.Result) int {
 		},
 	}
 
-	//// create a unique name generator
-	//nameGenerator := utils.NewUniqueNameGenerator()
-
 	// add column defs to the JSON output
 	for _, col := range result.Cols {
 		c := columnDef{


### PR DESCRIPTION
snapshot data
```
powerpipe query run "select 1 as a, 2 as a" --output pps
...
"data": {
  "columns": [
    {
      "name": "a",
      "data_type": "INT4"
    },
    {
      "name": "a_aqta",
      "data_type": "INT4",
      "original_name": "a"
    }
  ],
  "rows": [
    {
      "a": 1,
      "a_aqta": 2
    }
  ]
}
```

json output:
```
powerpipe query run "select 1 as a, 2 as a" --output json
{
 "columns": [
  {
   "name": "a",
   "data_type": "int4"
  },
  {
   "name": "a_rtvh",
   "data_type": "int4",
   "original_name": "a"
  }
 ],
 "rows": [
  {
   "a": 1,
   "a_rtvh": 2
  }
 ],
 "metadata": {
  "rows_returned": 1,
  "duration_ms": "2.096s"
 }
}
```