### PR TITLE
Updated the table column to display pretty formatted JSON when wrap is set to all

### DIFF
--- a/ui/dashboard/src/components/dashboards/Table/index.tsx
+++ b/ui/dashboard/src/components/dashboards/Table/index.tsx
@@ -589,7 +589,11 @@ const LineView = (props: TableProps) => {
                   <span
                     className={classNames(
                       "block",
-                      col.wrap === "all" ? "break-keep" : "truncate",
+                      col.wrap === "all" ? (
+                        col.data_type.toLowerCase() === "jsonb"
+                          ? "whitespace-pre"
+                          : "break-keep"
+                      ) : "truncate",
                     )}
                   >
                     <MemoCellValue

--- a/ui/dashboard/src/components/dashboards/Table/index.tsx
+++ b/ui/dashboard/src/components/dashboards/Table/index.tsx
@@ -469,7 +469,8 @@ const TableView = ({
                       "px-4 py-4 align-top content-center text-sm",
                       isNumericCol(cell.column.data_type) ? "text-right" : "",
                       cell.column.wrap === "all"
-                        ? "break-keep"
+                        ? (cell.column.data_type.toLowerCase() === "jsonb"
+                        ? "whitespace-pre" : "break-keep") 
                         : "whitespace-nowrap",
                     )}
                   >


### PR DESCRIPTION
Hi team, 

Thank you for all the efforts. 

In my experience, viewing JSON could be improved across tables (regular and line) in dashboards. Since the data itself is already pretty formatted, it made sense for targetted columns to show the JSON data how one would expect it to look when wrapped across lines.

Example:
```
table {
      title = "Users with Inline Policies"
      column "inline_policies" {
        wrap = "all"
      }
      sql = <<-EOQ
   select arn, inline_policies from aws_iam_user
  EOQ
    }
```
![image](https://github.com/user-attachments/assets/c38c1b31-bdea-4074-a752-242fe32ea884)
![image](https://github.com/user-attachments/assets/dd6c2017-fd2b-47bb-bab1-c6882bf64f8e)
