### PR TITLE
Table headers for numeric columns are not right-aligned like the row-level cell content. Fixes #755.

### DIFF
--- a/ui/dashboard/src/components/dashboards/Table/index.tsx
+++ b/ui/dashboard/src/components/dashboards/Table/index.tsx
@@ -1030,7 +1030,10 @@ const TableViewVirtualizedRows = (props: TableProps) => {
                         colSpan={header.colSpan}
                         scope="col"
                         className={classNames(
-                          "py-3 text-left font-normal tracking-wider whitespace-nowrap pl-4",
+                          "py-3 font-normal tracking-wider whitespace-nowrap px-4",
+                          isNumericCol(header.column.columnDef.data_type)
+                            ? "text-right"
+                            : "text-left",
                         )}
                         //style={{ width: header.getSize() }}
                       >


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d45998d7-2249-48ea-81d4-80ee59b75afd)
