### PR TITLE
Fix issue where powerpipe was exposing the server port to the internet even when listen was local. Closes #761

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -85,7 +85,7 @@ func runServerCmd(cmd *cobra.Command, _ []string) {
 	// setup a new webSocket service
 	webSocket := melody.New()
 	// create the dashboardServer
-	dashboardServer, err := dashboardserver.NewServer(ctx, modInitData, webSocket, serverPort, serverListen)
+	dashboardServer, err := dashboardserver.NewServer(ctx, modInitData, webSocket)
 	error_helpers.FailOnError(err)
 
 	// send it over to the powerpipe API Server
@@ -105,7 +105,7 @@ func runServerCmd(cmd *cobra.Command, _ []string) {
 		error_helpers.FailOnError(err)
 	}
 
-	dashboardserver.OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", serverPort, serverListen))
+	dashboardserver.OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", serverPort, viper.GetString(constants.ArgListen)))
 	dashboardserver.OutputMessage(ctx, fmt.Sprintf("Visit http://localhost:%d", serverPort))
 	dashboardserver.OutputMessage(ctx, "Press Ctrl+C to exit")
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -85,11 +85,15 @@ func runServerCmd(cmd *cobra.Command, _ []string) {
 	// setup a new webSocket service
 	webSocket := melody.New()
 	// create the dashboardServer
-	dashboardServer, err := dashboardserver.NewServer(ctx, modInitData, webSocket)
+	dashboardServer, err := dashboardserver.NewServer(ctx, modInitData, webSocket, serverPort, serverListen)
 	error_helpers.FailOnError(err)
 
 	// send it over to the powerpipe API Server
-	powerpipeService, err := api.NewAPIService(ctx, api.WithWebSocket(webSocket), api.WithWorkspace(modInitData.Workspace), api.WithHttpPort(serverPort))
+	powerpipeService, err := api.NewAPIService(ctx,
+		api.WithWebSocket(webSocket),
+		api.WithWorkspace(modInitData.Workspace),
+		api.WithHTTPPortAndListenConfig(serverPort, serverListen),
+	)
 	if err != nil {
 		error_helpers.FailOnError(err)
 	}
@@ -101,7 +105,7 @@ func runServerCmd(cmd *cobra.Command, _ []string) {
 		error_helpers.FailOnError(err)
 	}
 
-	dashboardserver.OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", serverPort, viper.GetString(constants.ArgListen)))
+	dashboardserver.OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", serverPort, serverListen))
 	dashboardserver.OutputMessage(ctx, fmt.Sprintf("Visit http://localhost:%d", serverPort))
 	dashboardserver.OutputMessage(ctx, "Press Ctrl+C to exit")
 

--- a/internal/dashboardserver/api.go
+++ b/internal/dashboardserver/api.go
@@ -10,14 +10,12 @@ import (
 
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
-	"github.com/spf13/viper"
-	"github.com/turbot/pipe-fittings/v2/constants"
 	"github.com/turbot/pipe-fittings/v2/error_helpers"
 	"github.com/turbot/pipe-fittings/v2/filepaths"
 	"gopkg.in/olahol/melody.v1"
 )
 
-func startAPIAsync(ctx context.Context, webSocket *melody.Melody) chan struct{} {
+func startAPIAsync(ctx context.Context, webSocket *melody.Melody, portVal int, listenVal ListenType) chan struct{} {
 	doneChan := make(chan struct{})
 
 	go func() {
@@ -42,9 +40,12 @@ func startAPIAsync(ctx context.Context, webSocket *melody.Melody) chan struct{} 
 			c.File(path.Join(assetsDirectory, "index.html"))
 		})
 
-		dashboardServerPort := viper.GetInt(constants.ArgPort)
+		// Use passed-in portVal and listenVal instead of viper
+		// dashboardServerPort := viper.GetInt(constants.ArgPort)
+		dashboardServerPort := portVal
 		dashboardServerListen := "localhost"
-		if viper.GetString(constants.ArgListen) == string(ListenTypeNetwork) {
+		// if viper.GetString(constants.ArgListen) == string(ListenTypeNetwork) {
+		if listenVal == ListenTypeNetwork {
 			dashboardServerListen = ""
 		}
 
@@ -61,7 +62,7 @@ func startAPIAsync(ctx context.Context, webSocket *melody.Melody) chan struct{} 
 			}
 		}()
 
-		OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", dashboardServerPort, viper.GetString(constants.ArgListen)))
+		OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", dashboardServerPort, listenVal))
 		OutputMessage(ctx, fmt.Sprintf("Visit http://localhost:%d", dashboardServerPort))
 		OutputMessage(ctx, "Press Ctrl+C to exit")
 		<-ctx.Done()

--- a/internal/dashboardserver/api.go
+++ b/internal/dashboardserver/api.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+	"github.com/turbot/pipe-fittings/v2/constants"
 	"github.com/turbot/pipe-fittings/v2/error_helpers"
 	"github.com/turbot/pipe-fittings/v2/filepaths"
 	"gopkg.in/olahol/melody.v1"
 )
 
-func startAPIAsync(ctx context.Context, webSocket *melody.Melody, portVal int, listenVal ListenType) chan struct{} {
+func startAPIAsync(ctx context.Context, webSocket *melody.Melody) chan struct{} {
 	doneChan := make(chan struct{})
 
 	go func() {
@@ -40,12 +42,10 @@ func startAPIAsync(ctx context.Context, webSocket *melody.Melody, portVal int, l
 			c.File(path.Join(assetsDirectory, "index.html"))
 		})
 
-		// Use passed-in portVal and listenVal instead of viper
-		// dashboardServerPort := viper.GetInt(constants.ArgPort)
-		dashboardServerPort := portVal
+		dashboardServerPort := viper.GetInt(constants.ArgPort)
+
 		dashboardServerListen := "localhost"
-		// if viper.GetString(constants.ArgListen) == string(ListenTypeNetwork) {
-		if listenVal == ListenTypeNetwork {
+		if viper.GetString(constants.ArgListen) == string(ListenTypeNetwork) {
 			dashboardServerListen = ""
 		}
 
@@ -62,7 +62,7 @@ func startAPIAsync(ctx context.Context, webSocket *melody.Melody, portVal int, l
 			}
 		}()
 
-		OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", dashboardServerPort, listenVal))
+		OutputReady(ctx, fmt.Sprintf("Dashboard server started on %d and listening on %s", dashboardServerPort, viper.GetString(constants.ArgListen)))
 		OutputMessage(ctx, fmt.Sprintf("Visit http://localhost:%d", dashboardServerPort))
 		OutputMessage(ctx, "Press Ctrl+C to exit")
 		<-ctx.Done()

--- a/internal/dashboardserver/server.go
+++ b/internal/dashboardserver/server.go
@@ -33,11 +33,9 @@ type Server struct {
 	workspace               *workspace.PowerpipeWorkspace
 	defaultDatabase         connection.ConnectionStringProvider
 	defaultSearchPathConfig backend.SearchPathConfig
-	listenPort              ListenPort
-	listenType              ListenType
 }
 
-func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket *melody.Melody, serverPort ListenPort, serverlisten ListenType) (*Server, error) {
+func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket *melody.Melody) (*Server, error) {
 	OutputWait(ctx, "Starting WorkspaceEvents Server")
 
 	var dashboardClients = make(map[string]*DashboardClientInfo)
@@ -53,8 +51,6 @@ func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket
 		workspace:               w,
 		defaultDatabase:         initData.DefaultDatabase,
 		defaultSearchPathConfig: initData.DefaultSearchPathConfig,
-		listenPort:              serverPort,
-		listenType:              serverlisten,
 	}
 
 	w.RegisterDashboardEventHandler(ctx, server.HandleDashboardEvent)
@@ -69,7 +65,7 @@ func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket
 // it returns a channel which is signalled when the API server terminates
 func (s *Server) Start(ctx context.Context) chan struct{} {
 	s.InitAsync(ctx)
-	return startAPIAsync(ctx, s.webSocket, int(s.listenPort), s.listenType)
+	return startAPIAsync(ctx, s.webSocket)
 }
 
 // Shutdown stops the API server

--- a/internal/dashboardserver/server.go
+++ b/internal/dashboardserver/server.go
@@ -33,9 +33,11 @@ type Server struct {
 	workspace               *workspace.PowerpipeWorkspace
 	defaultDatabase         connection.ConnectionStringProvider
 	defaultSearchPathConfig backend.SearchPathConfig
+	listenPort              ListenPort
+	listenType              ListenType
 }
 
-func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket *melody.Melody) (*Server, error) {
+func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket *melody.Melody, serverPort ListenPort, serverlisten ListenType) (*Server, error) {
 	OutputWait(ctx, "Starting WorkspaceEvents Server")
 
 	var dashboardClients = make(map[string]*DashboardClientInfo)
@@ -51,6 +53,8 @@ func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket
 		workspace:               w,
 		defaultDatabase:         initData.DefaultDatabase,
 		defaultSearchPathConfig: initData.DefaultSearchPathConfig,
+		listenPort:              serverPort,
+		listenType:              serverlisten,
 	}
 
 	w.RegisterDashboardEventHandler(ctx, server.HandleDashboardEvent)
@@ -65,7 +69,7 @@ func NewServer(ctx context.Context, initData *initialisation.InitData, webSocket
 // it returns a channel which is signalled when the API server terminates
 func (s *Server) Start(ctx context.Context) chan struct{} {
 	s.InitAsync(ctx)
-	return startAPIAsync(ctx, s.webSocket)
+	return startAPIAsync(ctx, s.webSocket, int(s.listenPort), s.listenType)
 }
 
 // Shutdown stops the API server


### PR DESCRIPTION
Fixed issue where powerpipe was exposing the server port(9033) to the internet even when arg `--listen` was set to local. 

Before (notice *:9033 (LISTEN)):
![Screenshot 2025-05-15 at 11 56 04 AM](https://github.com/user-attachments/assets/c5c0474e-3656-46c9-b09e-2583e2e54d26)

Now (notice localhost:9033 (LISTEN)):
![Screenshot 2025-05-15 at 11 56 35 AM](https://github.com/user-attachments/assets/11045801-aa70-45b9-b3b2-073afde5f2e3)

