### PR TITLE
Convert boolean values to strings for proper pie/donut chart rendering. Fixes #433

### DIFF
--- a/ui/dashboard/src/components/dashboards/common/index.ts
+++ b/ui/dashboard/src/components/dashboards/common/index.ts
@@ -79,6 +79,13 @@ type ChartDatasetResponse = {
   transform: ChartTransform;
 };
 
+const toStringIfBoolean = (value: any): any | string => {
+  if (typeof value === "boolean") {
+    return value.toString();
+  }
+  return value;
+};
+
 const crosstabDataTransform = (data: LeafNodeData): ChartDatasetResponse => {
   if (data.columns.length < 3) {
     return { dataset: [], rowSeriesLabels: [], transform: "none" };
@@ -88,17 +95,10 @@ const crosstabDataTransform = (data: LeafNodeData): ChartDatasetResponse => {
   const xAxisLabels: string[] = [];
   const seriesLabels: string[] = [];
   for (const row of data.rows) {
-    let xAxisLabel = row[data.columns[0].name];
-    let seriesName = row[data.columns[1].name];
-    const seriesValue = row[data.columns[2].name];
-    
     // Convert boolean values to strings for proper chart rendering
-    if (typeof xAxisLabel === "boolean") {
-      xAxisLabel = xAxisLabel.toString();
-    }
-    if (typeof seriesName === "boolean") {
-      seriesName = seriesName.toString();
-    }
+    const xAxisLabel = toStringIfBoolean(row[data.columns[0].name]);
+    const seriesName = toStringIfBoolean(row[data.columns[1].name]);
+    const seriesValue = row[data.columns[2].name];
 
     if (!xAxis[xAxisLabel]) {
       xAxis[xAxisLabel] = {};
@@ -144,14 +144,10 @@ const defaultDataTransform = (data: LeafNodeData): ChartDatasetResponse => {
   return {
     dataset: [
       data.columns.map((col) => col.name),
-      ...data.rows.map((row) => data.columns.map((col) => {
-        const value = row[col.name];
+      ...data.rows.map((row) =>
         // Convert boolean values to strings for proper chart rendering
-        if (typeof value === "boolean") {
-          return value.toString();
-        }
-        return value;
-      })),
+        data.columns.map((col) => toStringIfBoolean(row[col.name])),
+      ),
     ],
     rowSeriesLabels: [],
     transform: "none",

--- a/ui/dashboard/src/components/dashboards/common/index.ts
+++ b/ui/dashboard/src/components/dashboards/common/index.ts
@@ -79,11 +79,11 @@ type ChartDatasetResponse = {
   transform: ChartTransform;
 };
 
-const toStringIfBoolean = <T>(value: T): string | Exclude<T, boolean> => {
+const toStringIfBoolean = <T>(value: T): string | T => {
   if (typeof value === "boolean") {
     return value.toString();
   }
-  return value as Exclude<T, boolean>;
+  return value;
 };
 
 const crosstabDataTransform = (data: LeafNodeData): ChartDatasetResponse => {

--- a/ui/dashboard/src/components/dashboards/common/index.ts
+++ b/ui/dashboard/src/components/dashboards/common/index.ts
@@ -88,9 +88,17 @@ const crosstabDataTransform = (data: LeafNodeData): ChartDatasetResponse => {
   const xAxisLabels: string[] = [];
   const seriesLabels: string[] = [];
   for (const row of data.rows) {
-    const xAxisLabel = row[data.columns[0].name];
-    const seriesName = row[data.columns[1].name];
+    let xAxisLabel = row[data.columns[0].name];
+    let seriesName = row[data.columns[1].name];
     const seriesValue = row[data.columns[2].name];
+    
+    // Convert boolean values to strings for proper chart rendering
+    if (typeof xAxisLabel === "boolean") {
+      xAxisLabel = xAxisLabel.toString();
+    }
+    if (typeof seriesName === "boolean") {
+      seriesName = seriesName.toString();
+    }
 
     if (!xAxis[xAxisLabel]) {
       xAxis[xAxisLabel] = {};
@@ -136,7 +144,14 @@ const defaultDataTransform = (data: LeafNodeData): ChartDatasetResponse => {
   return {
     dataset: [
       data.columns.map((col) => col.name),
-      ...data.rows.map((row) => data.columns.map((col) => row[col.name])),
+      ...data.rows.map((row) => data.columns.map((col) => {
+        const value = row[col.name];
+        // Convert boolean values to strings for proper chart rendering
+        if (typeof value === "boolean") {
+          return value.toString();
+        }
+        return value;
+      })),
     ],
     rowSeriesLabels: [],
     transform: "none",

--- a/ui/dashboard/src/components/dashboards/common/index.ts
+++ b/ui/dashboard/src/components/dashboards/common/index.ts
@@ -79,11 +79,11 @@ type ChartDatasetResponse = {
   transform: ChartTransform;
 };
 
-const toStringIfBoolean = (value: any): any | string => {
+const toStringIfBoolean = <T>(value: T): string | Exclude<T, boolean> => {
   if (typeof value === "boolean") {
     return value.toString();
   }
-  return value;
+  return value as Exclude<T, boolean>;
 };
 
 const crosstabDataTransform = (data: LeafNodeData): ChartDatasetResponse => {


### PR DESCRIPTION
## Summary
- Fixes issue where pie and donut charts were not rendering correctly when using boolean values as grouping variables
- Converts boolean values to strings in data transformation functions to ensure proper chart rendering

## Test plan
- [x] Build the UI dashboard successfully  
- [x] Verified that boolean values are properly converted to strings in both default and crosstab data transforms
- [x] Test with actual RDS Multi AZ chart using `multi_az` boolean column
- [x] Verify donut and pie charts render correctly with boolean group by variables

Fixes #433

🤖 Generated with [Claude Code](https://claude.ai/code)