### PR TITLE
Fix framer-motion build error closes #974

### DIFF
--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -136,7 +136,8 @@
     "esbuild": "0.25.0",
     "serialize-javascript": "6.0.2",
     "prismjs": "1.30.0",
-    "pbkdf2": "3.1.3"
+    "pbkdf2": "3.1.3",
+    "framer-motion": "11.11.17"
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
## Summary
- Pins framer-motion to 11.11.17 to resolve Storybook build incompatibility

## Problem
Framer-motion 12.x removed the `GroupPlaybackControls` export that Storybook 8.6.14 depends on, causing this build error:

```
Attempted import error: 'GroupPlaybackControls' is not exported from 'motion-dom'
```

## Solution
Added yarn resolution to pin framer-motion to version 11.11.17 (last 11.x release) which is compatible with Storybook 8.6.14.

## Testing
- Build completes successfully with this change
- Dashboard builds without errors

## Related
- Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)