### PR TITLE
Add dashboard UI tests to CI closes #977

### DIFF
--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -14,6 +14,31 @@ env:
   SPIPETOOLS_TOKEN: ${{ secrets.SPIPETOOLS_TOKEN }}
 
 jobs:
+  dashboard_tests:
+    name: Dashboard UI Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: |
+          cd ui/dashboard
+          yarn install
+
+      - name: Run tests
+        run: |
+          cd ui/dashboard
+          yarn test --watchAll=false
+
   goreleaser:
     name: Build
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary
- Adds dashboard UI tests (`yarn test`) to PR CI workflow
- Runs in parallel with build job for fast feedback

## Problem
Dashboard tests were only run during releases, not on PRs. This meant UI regressions could go undetected until release time (see PR #975 where commit 1 added a failing test but CI showed green).

## Solution
Added new `dashboard_tests` job to `11-test-acceptance.yaml` that:
- Runs on `ubuntu-latest` with Node.js 20
- Uses Corepack for Yarn 4.5.3 compatibility  
- Installs dependencies with `yarn install`
- Runs tests with `yarn test --watchAll=false`

## Why This Phase?
The job runs **in parallel** with the build (no `needs:` clause) because:
- Dashboard tests don't need the compiled binary
- Provides faster feedback to developers
- Total CI time is `max(dashboard_tests, build)` instead of additive

## Testing
This PR will validate the workflow works correctly - the revised workflow in this branch will run when the PR is created, proving the dashboard tests execute successfully in CI.

## Related
- Closes #977
- Discovered while working on PR #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)