### PR TITLE
Add copy button to graph error panels for LLM debugging

### DIFF
--- a/ui/dashboard/src/components/dashboards/common/NodeAndEdgePanelInformation.tsx
+++ b/ui/dashboard/src/components/dashboards/common/NodeAndEdgePanelInformation.tsx
@@ -1,15 +1,18 @@
+import CopyToClipboard from "@powerpipe/components/CopyToClipboard";
 import ErrorMessage from "@powerpipe/components/ErrorMessage";
 import Icon from "@powerpipe/components/Icon";
 import LoadingIndicator from "@powerpipe/components/dashboards/LoadingIndicator";
-import { DashboardRunState } from "@powerpipe/types";
+import { DashboardRunState, PanelDefinition } from "@powerpipe/types";
 import {
   EdgeStatus,
   GraphStatuses,
   NodeStatus,
+  WithStatus,
 } from "@powerpipe/components/dashboards/graphs/types";
 import { Node } from "reactflow";
 
 type NodeAndEdgePanelInformationProps = {
+  panel: PanelDefinition;
   nodes: Node[];
   status: DashboardRunState;
   statuses: GraphStatuses;
@@ -20,6 +23,94 @@ const nodeOrEdgeTitle = (nodeOrEdge: NodeStatus | EdgeStatus) =>
   nodeOrEdge?.category?.title ||
   nodeOrEdge?.category?.name ||
   nodeOrEdge.id;
+
+const formatNodeAndEdgeErrorsForCopy = (
+  panel: PanelDefinition,
+  statuses: GraphStatuses,
+): string => {
+  const {
+    error: errorStatuses,
+    running: runningStatuses,
+    blocked: blockedStatuses,
+    complete: completeStatuses,
+  } = statuses;
+
+  // Build markdown format
+  let output = `# Graph Panel Error Report\n\n`;
+  output += `**Panel:** ${panel.name}\n`;
+  output += `**Type:** ${panel.panel_type || "graph"}\n`;
+  output += `**Status:** ${panel.status || "unknown"}\n`;
+  output += `**Timestamp:** ${new Date().toISOString()}\n\n`;
+
+  // Summary section
+  output += `## Summary\n`;
+  output += `- Complete: ${completeStatuses.nodes.length} nodes, ${completeStatuses.edges.length} edges, ${completeStatuses.withs.length} withs\n`;
+  output += `- Running: ${runningStatuses.nodes.length} nodes, ${runningStatuses.edges.length} edges, ${runningStatuses.withs.length} withs\n`;
+  output += `- Waiting: ${blockedStatuses.nodes.length} nodes, ${blockedStatuses.edges.length} edges, ${blockedStatuses.withs.length} withs\n`;
+  output += `- **Errors: ${errorStatuses.nodes.length} nodes, ${errorStatuses.edges.length} edges, ${errorStatuses.withs.length} withs**\n\n`;
+
+  // Only include error details if there are errors
+  if (errorStatuses.total === 0) {
+    return output;
+  }
+
+  output += `## Error Details\n\n`;
+
+  // With errors
+  if (errorStatuses.withs.length > 0) {
+    errorStatuses.withs.forEach((withBlock: WithStatus) => {
+      output += `### With: ${withBlock.id}\n`;
+      if (withBlock.title) {
+        output += `**Title:** ${withBlock.title}\n`;
+      }
+      if (withBlock.error) {
+        output += `**Error:**\n\`\`\`\n${withBlock.error}\n\`\`\`\n\n`;
+      } else {
+        output += `**Error:** (no error message provided)\n\n`;
+      }
+    });
+  }
+
+  // Node errors
+  if (errorStatuses.nodes.length > 0) {
+    errorStatuses.nodes.forEach((node: NodeStatus) => {
+      output += `### Node: ${node.id}\n`;
+      const title = nodeOrEdgeTitle(node);
+      if (title && title !== node.id) {
+        output += `**Title:** ${title}\n`;
+      }
+      if (node.category?.title) {
+        output += `**Category:** ${node.category.title}\n`;
+      }
+      if (node.error) {
+        output += `**Error:**\n\`\`\`\n${node.error}\n\`\`\`\n\n`;
+      } else {
+        output += `**Error:** (no error message provided)\n\n`;
+      }
+    });
+  }
+
+  // Edge errors
+  if (errorStatuses.edges.length > 0) {
+    errorStatuses.edges.forEach((edge: EdgeStatus) => {
+      output += `### Edge: ${edge.id}\n`;
+      const title = nodeOrEdgeTitle(edge);
+      if (title && title !== edge.id) {
+        output += `**Title:** ${title}\n`;
+      }
+      if (edge.category?.title) {
+        output += `**Category:** ${edge.category.title}\n`;
+      }
+      if (edge.error) {
+        output += `**Error:**\n\`\`\`\n${edge.error}\n\`\`\`\n\n`;
+      } else {
+        output += `**Error:** (no error message provided)\n\n`;
+      }
+    });
+  }
+
+  return output;
+};
 
 const WaitingRow = ({ title }) => (
   <div className="flex items-center space-x-1">
@@ -56,17 +147,29 @@ const ErrorRow = ({ title, error }: { title: string; error?: string }) => (
 );
 
 const NodeAndEdgePanelInformation = ({
+  panel,
   nodes,
   status,
   statuses,
-}: NodeAndEdgePanelInformationProps) => (
-  <div className="space-y-2 overflow-y-scroll">
-    <div className="space-y-1">
-      <div>
-        {statuses.complete.total} complete, {statuses.running.total} running,{" "}
-        {statuses.blocked.total} waiting, {statuses.error.total}{" "}
-        {statuses.error.total === 1 ? "error" : "errors"}.
+}: NodeAndEdgePanelInformationProps) => {
+  const copyData = formatNodeAndEdgeErrorsForCopy(panel, statuses);
+
+  return (
+    <div className="space-y-2 overflow-y-scroll">
+      {/* Copy button - minimal, just the icon */}
+      <div className="flex justify-end px-4 pt-2" title="Copy to clipboard">
+        <CopyToClipboard
+          data={copyData}
+          className="text-foreground-light hover:text-foreground transition-colors"
+        />
       </div>
+
+      <div className="space-y-1 px-4">
+        <div>
+          {statuses.complete.total} complete, {statuses.running.total} running,{" "}
+          {statuses.blocked.total} waiting, {statuses.error.total}{" "}
+          {statuses.error.total === 1 ? "error" : "errors"}.
+        </div>
       {statuses.initialized.total === 0 &&
         statuses.blocked.total === 0 &&
         statuses.running.total === 0 &&
@@ -134,8 +237,9 @@ const NodeAndEdgePanelInformation = ({
           error={edge.error}
         />
       ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default NodeAndEdgePanelInformation;

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -411,6 +411,7 @@ const CustomControls = () => {
 };
 
 const useNodeAndEdgePanelInformation = (
+  panel: GraphProps,
   nodeAndEdgeStatus: NodeAndEdgeStatus,
   dataFormat: NodeAndEdgeDataFormat,
   nodes: Node[],
@@ -566,6 +567,7 @@ const useNodeAndEdgePanelInformation = (
     // @ts-ignore
     setPanelInformation(() => (
       <NodeAndEdgePanelInformation
+        panel={panel}
         nodes={nodes}
         status={status}
         statuses={statuses}
@@ -573,6 +575,7 @@ const useNodeAndEdgePanelInformation = (
     ));
     setShowPanelInformation(true);
   }, [
+    panel,
     dataFormat,
     nodeAndEdgeStatus,
     nodes,
@@ -587,6 +590,7 @@ const Graph = (props) => {
   const { selectedPanel } = useDashboardPanelDetail();
   const graphOptions = useGraphOptions(props);
   useNodeAndEdgePanelInformation(
+    props,
     props.nodeAndEdgeStatus,
     props.dataFormat,
     graphOptions.nodes,

--- a/ui/dashboard/src/components/dashboards/layout/Panel/PanelStatus.tsx
+++ b/ui/dashboard/src/components/dashboards/layout/Panel/PanelStatus.tsx
@@ -1,3 +1,4 @@
+import CopyToClipboard from "@powerpipe/components/CopyToClipboard";
 import ErrorMessage from "../../../ErrorMessage";
 import Icon from "../../../Icon";
 import LoadingIndicator from "@powerpipe/components/dashboards/LoadingIndicator";
@@ -22,6 +23,22 @@ type BasePanelStatusProps = {
   children: ReactNode;
   className?: string;
   definition: PanelDefinition;
+};
+
+const formatPanelErrorForCopy = (panel: PanelDefinition): string => {
+  let output = `# Panel Error Report\n\n`;
+  output += `**Panel:** ${panel.name}\n`;
+  output += `**Type:** ${panel.panel_type || "unknown"}\n`;
+  output += `**Status:** ${panel.status || "error"}\n`;
+  output += `**Timestamp:** ${new Date().toISOString()}\n\n`;
+
+  if (panel.error) {
+    output += `## Error Message\n\`\`\`\n${panel.error}\n\`\`\`\n`;
+  } else {
+    output += `## Error Message\n\`\`\`\n(no error message provided)\n\`\`\`\n`;
+  }
+
+  return output;
 };
 
 const BasePanelStatus = ({
@@ -150,21 +167,36 @@ const PanelCancelled = ({ definition }) => {
 };
 
 const PanelError = ({ definition }) => {
+  const copyData = formatPanelErrorForCopy(definition);
+
   return (
     <BasePanelStatus
       className="bg-alert-light border-alert text-foreground"
       definition={definition}
     >
-      <div className="flex items-center space-x-1">
-        <Icon
-          className="w-3.5 h-3.5 text-alert shrink-0"
-          icon="materialsymbols-solid:error"
-        />
-        <span className="block truncate">Error</span>
+      <div className="space-y-2">
+        {/* Header with error icon and copy button */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-1">
+            <Icon
+              className="w-3.5 h-3.5 text-alert shrink-0"
+              icon="materialsymbols-solid:error"
+            />
+            <span className="block truncate">Error</span>
+          </div>
+          <div title="Copy to clipboard">
+            <CopyToClipboard
+              data={copyData}
+              className="text-foreground-light hover:text-foreground transition-colors"
+            />
+          </div>
+        </div>
+
+        {/* Error message */}
+        <span className="block">
+          <ErrorMessage error={definition.error} />
+        </span>
       </div>
-      <span className="block">
-        <ErrorMessage error={definition.error} />
-      </span>
     </BasePanelStatus>
   );
 };


### PR DESCRIPTION
## Summary

Adds a copy-to-clipboard button to graph error displays to make it easy for users to copy error information for debugging with LLMs.

## Features

- **Minimal UI**: Just copy icon in top-right corner, no header text
- **Tooltip**: "Copy to clipboard" on hover
- **Markdown Format**: Optimized for LLM consumption
- **Rich Metadata**: Includes panel name, type, status, and timestamp
- **Comprehensive Context**: 
  - NODE_AND_EDGE format: Complete status summary + detailed per-node/edge errors
  - Legacy format: Panel-level error with metadata
- **Visual Feedback**: Icon changes to filled + green for 1 second on success

## Copy Format Examples

### NODE_AND_EDGE Format (Modern Graphs)

```markdown
# Graph Panel Error Report

**Panel:** aws_infrastructure_graph
**Type:** graph
**Status:** error
**Timestamp:** 2025-11-20T15:30:45.123Z

## Summary
- Complete: 45 nodes, 12 edges, 0 withs
- Running: 2 nodes, 0 edges, 0 withs
- Waiting: 5 nodes, 0 edges, 0 withs
- **Errors: 3 nodes, 1 edge, 0 withs**

## Error Details

### Node: aws_vpc_123
**Title:** VPC Configuration
**Error:**
```
Connection timeout after 30 seconds
```

[... additional errors ...]
```

### Legacy Format (Panel Errors)

```markdown
# Panel Error Report

**Panel:** aws_infrastructure_graph
**Type:** graph
**Status:** error
**Timestamp:** 2025-11-20T15:30:45.123Z

## Error Message
```
Connection timeout after 30 seconds
```
```

## Files Modified

- `NodeAndEdgePanelInformation.tsx` - Added copy button and formatting helper
- `Graph/index.tsx` - Pass panel prop to information component  
- `PanelStatus.tsx` - Added copy button to error display

## Testing

To test:
1. Run a dashboard with graph panels that have errors
2. Verify copy button appears in top-right of error panel
3. Click copy button
4. Verify icon changes to filled + green
5. Paste copied content
6. Verify Markdown format with complete error context

## Future Work

See `.claude/wip/graph-error-copy-button/PROJECT-PHASES.md` for Phase 2:
- Investigation of other component types that could benefit from copy functionality
- Potential expansion to tables, charts, flows, hierarchies, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>