### PR TITLE
Update npm dependencies to remediate security vulnerabilities

### DIFF
--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -140,7 +140,9 @@
     "webpack-dev-server": "5.2.1",
     "js-yaml": "4.1.1",
     "glob": "10.5.0",
-    "qs": "6.14.1"
+    "qs": "6.14.1",
+    "mdast-util-to-hast": "13.2.1",
+    "on-headers": "1.1.0"
   },
   "engines": {
     "node": ">=20",

--- a/ui/dashboard/yarn.lock
+++ b/ui/dashboard/yarn.lock
@@ -12500,9 +12500,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-hast@npm:^13.0.0":
-  version: 13.2.0
-  resolution: "mdast-util-to-hast@npm:13.2.0"
+"mdast-util-to-hast@npm:13.2.1":
+  version: 13.2.1
+  resolution: "mdast-util-to-hast@npm:13.2.1"
   dependencies:
     "@types/hast": "npm:^3.0.0"
     "@types/mdast": "npm:^4.0.0"
@@ -12513,7 +12513,7 @@ __metadata:
     unist-util-position: "npm:^5.0.0"
     unist-util-visit: "npm:^5.0.0"
     vfile: "npm:^6.0.0"
-  checksum: 10c0/9ee58def9287df8350cbb6f83ced90f9c088d72d4153780ad37854f87144cadc6f27b20347073b285173b1649b0723ddf0b9c78158608a804dcacb6bda6e1816
+  checksum: 10c0/3eeaf28a5e84e1e08e6d54a1a8a06c0fca88cb5d36f4cf8086f0177248d1ce6e4e751f4ad0da19a3dea1c6ea61bd80784acc3ae021e44ceeb21aa5413a375e43
   languageName: node
   linkType: hard
 
@@ -13628,10 +13628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-headers@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "on-headers@npm:1.0.2"
-  checksum: 10c0/f649e65c197bf31505a4c0444875db0258e198292f34b884d73c2f751e91792ef96bb5cf89aa0f4fecc2e4dc662461dda606b1274b0e564f539cae5d2f5fc32f
+"on-headers@npm:1.1.0":
+  version: 1.1.0
+  resolution: "on-headers@npm:1.1.0"
+  checksum: 10c0/2c3b6b0d68ec9adbd561dc2d61c9b14da8ac03d8a2f0fd9e97bdf0600c887d5d97f664ff3be6876cf40cda6e3c587d73a4745e10b426ac50c7664fc5a0dfc0a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Update `node-forge` resolution: 1.3.0 → 1.3.2 (fixes CVE-2025-66030, CVE-2025-66031, CVE-2025-12816 - high/medium)
- Update `storybook` direct dependency: 8.6.14 → 8.6.15 (fixes CVE-2025-68429 - high)
- Add `qs` resolution: 6.14.1 (fixes CVE-2025-15284 - high)
- Add `mdast-util-to-hast` resolution: 13.2.1 (fixes CVE-2025-66400 - medium)
- Add `on-headers` resolution: 1.1.0 (fixes CVE-2025-7339 - low)

## Test plan
- [x] Verify `yarn install` completes successfully
- [x] Verify dashboard UI builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)