### PR TITLE
Update go and npm dependencies to remediate security vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	cloud.google.com/go/monitoring v1.24.0 // indirect
 	cloud.google.com/go/storage v1.52.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
-	filippo.io/edwards25519 v1.1.0 // indirect
+	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -617,8 +617,8 @@ cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcP
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
-filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
+filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=

--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -140,14 +140,14 @@
     "webpack-dev-server": "5.2.1",
     "js-yaml": "4.1.1",
     "glob": "10.5.0",
-    "qs": "6.14.1",
+    "qs": "6.14.2",
     "mdast-util-to-hast": "13.2.1",
     "on-headers": "1.1.0",
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "lodash-es": "4.17.23",
     "lodash": "4.17.23",
     "@remix-run/router": "1.23.2",
-    "jsonpath": "1.2.0"
+    "jsonpath": "1.2.1"
   },
   "engines": {
     "node": ">=20",

--- a/ui/dashboard/yarn.lock
+++ b/ui/dashboard/yarn.lock
@@ -11900,14 +11900,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath@npm:1.2.0":
-  version: 1.2.0
-  resolution: "jsonpath@npm:1.2.0"
+"jsonpath@npm:1.2.1":
+  version: 1.2.1
+  resolution: "jsonpath@npm:1.2.1"
   dependencies:
     esprima: "npm:1.2.5"
     static-eval: "npm:2.1.1"
     underscore: "npm:1.13.6"
-  checksum: 10c0/730efd4b9b78d72b5fb03f53bd8246f19882aa5009895bd5c95fda5d9df19a21132ed3cc805f2c5ca25764718eac5a1a871b43e07804e993791c2f7f8f823d33
+  checksum: 10c0/673d4e33c586c11eba16f19c212929fcf397d08f67341c7e2b70730b0c80f137ab18383f7a2e04622090fec065d979e19a714fc51e1b67412c989c855a1f2fc6
   languageName: node
   linkType: hard
 
@@ -15308,12 +15308,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.14.1":
-  version: 6.14.1
-  resolution: "qs@npm:6.14.1"
+"qs@npm:6.14.2":
+  version: 6.14.2
+  resolution: "qs@npm:6.14.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/0e3b22dc451f48ce5940cbbc7c7d9068d895074f8c969c0801ac15c1313d1859c4d738e46dc4da2f498f41a9ffd8c201bd9fb12df67799b827db94cc373d2613
+  checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
   languageName: node
   linkType: hard
 
@@ -17746,16 +17746,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:7.5.8":
+  version: 7.5.8
+  resolution: "tar@npm:7.5.8"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/8569db1b49f5d72084cbdcad9d2b39fcc115993186455aa052c1da0a2739b20e2d94af6a23609fc25d3ae63c9fed8b159f3b1d16b699e9ef25e3b8464603d153
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- **tar**: 7.5.7 → 7.5.8 (CVE-2026-26960, high) - Arbitrary File Read/Write via Hardlink Target Escape
- **qs**: 6.14.1 → 6.14.2 (CVE-2026-2391, low) - arrayLimit bypass in comma parsing allows DoS
- **jsonpath**: 1.2.0 → 1.2.1 (CVE-2026-1615, high) - Arbitrary Code Injection via unsafe evaluation
- **filippo.io/edwards25519**: 1.1.0 → 1.1.1 (CVE-2026-26958, low) - MultiScalarMult invalid results

### Not addressed
- **elliptic** (CVE-2025-14505, low): Already at latest version 6.6.1; no patched version available yet

## Test plan
- [x] Go build (`make`) succeeds
- [x] Dashboard UI build (`yarn build`) succeeds
- [x] `yarn why` confirms updated versions for tar, qs, jsonpath
- [x] `go.mod` confirms edwards25519 v1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)