### PR TITLE
Cherry-pick #1034: workflow permissions for v1.5.1 release

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -21,6 +21,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: write
+
 env:
   POWERPIPE_UPDATE_CHECK: false
   GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -188,7 +191,7 @@ jobs:
           path: pipe-fittings
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Install Docker (if needed)
         run: |
@@ -223,7 +226,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26"
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Download Dashboard UI Assets Artifact

--- a/.github/workflows/02-powerpipe-smoke-tests.yaml
+++ b/.github/workflows/02-powerpipe-smoke-tests.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   # Version from input, used to download the correct release artifacts
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Test Linting
@@ -29,13 +32,13 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.4
+          version: latest
           args: --timeout=10m
           working-directory: powerpipe
           skip-cache: true

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   POWERPIPE_UPDATE_CHECK: false
   SPIPETOOLS_TOKEN: ${{ secrets.SPIPETOOLS_TOKEN }}
@@ -63,7 +66,7 @@ jobs:
           go test -timeout 30s ./... -test.v
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Install Docker (if needed)
         run: |
@@ -79,7 +82,7 @@ jobs:
        # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Build
@@ -146,7 +149,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26
           cache: false
 
       - name: Prepare for downloads

--- a/.github/workflows/12-test-post-release-linux-distros.yaml
+++ b/.github/workflows/12-test-post-release-linux-distros.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   # Version from input, used to download the correct release artifacts
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/30-stale.yaml
+++ b/.github/workflows/30-stale.yaml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
+++ b/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-pipeling-issue-tracker.yml@main


### PR DESCRIPTION
Cherry-picks the workflow hardening from develop onto v1.5.x so the release workflow can push the v1.5.1 tag. Org-wide default GITHUB_TOKEN was changed to read; this adds explicit permissions: contents: write to the workflows. Required for today's CVE remediation release.