### PR TITLE
Cherry-pick #1034: workflow permissions for v1.5.1 release

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -21,6 +21,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: write
+
 env:
   POWERPIPE_UPDATE_CHECK: false
   GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/02-powerpipe-smoke-tests.yaml
+++ b/.github/workflows/02-powerpipe-smoke-tests.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   # Version from input, used to download the correct release artifacts
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Test Linting

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   POWERPIPE_UPDATE_CHECK: false
   SPIPETOOLS_TOKEN: ${{ secrets.SPIPETOOLS_TOKEN }}

--- a/.github/workflows/12-test-post-release-linux-distros.yaml
+++ b/.github/workflows/12-test-post-release-linux-distros.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   # Version from input, used to download the correct release artifacts
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/30-stale.yaml
+++ b/.github/workflows/30-stale.yaml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
+++ b/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-pipeling-issue-tracker.yml@main


### PR DESCRIPTION
Proper cherry-pick of 836bfb5497 onto v1.5.x. Adds explicit permissions: contents: write to workflows so the release workflow can push the v1.5.1 tag (org-wide default GITHUB_TOKEN was changed to read). Conflicts on docker/setup-buildx-action SHA in 01-powerpipe-release.yaml and 11-test-acceptance.yaml resolved by keeping HEAD (v1.5.x had the newer v3.10.0 SHA from #1039). Go 1.26.1 preserved. Required for today's CVE remediation release.