### PR TITLE
CHANGELOG for powerpipe v1.5.2 (pgx v5.9.2, CVE-2026-41889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.5.2 [2026-05-19]
+_What's new_
+- Compiled with Go 1.26.1.
+
+_Dependencies_
+- Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 ([GHSA-j88v-2chj-qfwx](https://github.com/advisories/GHSA-j88v-2chj-qfwx)).
+
 ## v1.5.0 [2026-02-27]
 _What's new_
 - Compiled with Go 1.26.


### PR DESCRIPTION
Release-prep PR for **powerpipe v1.5.2**.

The pgx v5.9.2 + Go 1.26.1 security fix is already merged on `v1.5.x` (#1061). The release workflow does not write `CHANGELOG.md`, so this PR adds the CHANGELOG entry the release runbook requires.

## Changes

Adds a top `## v1.5.2 [2026-05-19]` entry to `CHANGELOG.md`:

- _What's new_: Compiled with Go 1.26.1.
- _Dependencies_: Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 (GHSA-j88v-2chj-qfwx).

Heading and section style match the existing CHANGELOG conventions (`## vX.Y.Z [date]`, `_What's new_` / `_Dependencies_`, Go version under _What's new_).

## Scope

Documentation only — no code changes. PR only; no merge, tag, or release.
