### PR TITLE
Pin js-yaml, svgo, @tootallnate/once in dashboard UI

### DIFF
--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -139,7 +139,7 @@
     "pbkdf2": "3.1.3",
     "webpack-dev-server": "5.2.6",
     "postcss": "8.5.23",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "glob": "10.5.0",
     "qs": "6.15.3",
     "ws@^8.18.0": "8.21.1",
@@ -148,7 +148,7 @@
     "on-headers": "1.1.0",
     "tar": "7.5.22",
     "flatted": "3.4.2",
-    "svgo": "2.8.1",
+    "svgo": "2.8.3",
     "underscore": "1.13.8",
     "brace-expansion": "1.1.16",
     "picomatch": "2.3.2",
@@ -158,7 +158,8 @@
     "@remix-run/router": "1.23.3",
     "ip-address": "10.3.1",
     "jsonpath": "1.3.0",
-    "rollup": "2.80.0"
+    "rollup": "2.80.0",
+    "@tootallnate/once": "2.0.1"
   },
   "engines": {
     "node": ">=20",

--- a/ui/dashboard/yarn.lock
+++ b/ui/dashboard/yarn.lock
@@ -4219,10 +4219,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:1":
-  version: 1.1.2
-  resolution: "@tootallnate/once@npm:1.1.2"
-  checksum: 10c0/8fe4d006e90422883a4fa9339dd05a83ff626806262e1710cee5758d493e8cbddf2db81c0e4690636dc840b02c9fda62877866ea774ebd07c1777ed5fafbdec6
+"@tootallnate/once@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@tootallnate/once@npm:2.0.1"
+  checksum: 10c0/23b01a341485be711c602077936d70f8e695405bb88ab4433dc6d1e6cb4556401518789574d399eded790b70b27738136c9a8f02df7ae4219f4ba28bb22d586b
   languageName: node
   linkType: hard
 
@@ -12078,14 +12078,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -17897,9 +17897,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:2.8.1":
-  version: 2.8.1
-  resolution: "svgo@npm:2.8.1"
+"svgo@npm:2.8.3":
+  version: 2.8.3
+  resolution: "svgo@npm:2.8.3"
   dependencies:
     commander: "npm:^7.2.0"
     css-select: "npm:^4.1.3"
@@ -17910,7 +17910,7 @@ __metadata:
     stable: "npm:^0.1.8"
   bin:
     svgo: ./bin/svgo
-  checksum: 10c0/67fe1fcdcd47376aaa655e10c8ca7939fcf28d7e47240fc802da814dfcc2170a64598d882967c832935c3302633057c7d2e7fbc566c35d21d927536c5bf93e06
+  checksum: 10c0/0052299bbc4c76e22312e4e7288772e9a5655e850622f67a7d61609469ea4da608047e89ebc432d9aab854a559d98d3f4b8b06c89f899f227214cc5145c4933a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #1096 for three Dependabot alerts it did not cover.

| CVE | Severity | Package | Fix |
|---|---|---|---|
| — | HIGH | js-yaml | 4.3.0 |
| — | HIGH | svgo | 2.8.3 |
| CVE-2026-3449 | LOW | @tootallnate/once | 2.0.1 |

## Not included: brace-expansion

CVE-2026-14257 wants brace-expansion 5.0.8. Its range is `<= 5.0.7` with no lower bound, so the 1.1.16 pin from #1096 is still inside it. Forcing 5.0.8 breaks the build:

```
expand is not a function
```

brace-expansion 5.x is ESM-only and exports `expand` as a named binding, while the pinned `minimatch` 3.1.4 requires it as a callable default. Reaching 5.0.8 would mean unpinning minimatch off 3.x, which is a much larger change than this advisory warrants. Recommend snoozing CVE-2026-14257 in Vanta with auto-reopen instead.

## Verification

- `yarn install` clean; lock confirms js-yaml 4.3.0, svgo 2.8.3, @tootallnate/once 2.0.1, brace-expansion still 1.1.16
- `yarn build` (craco production build) succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)