### PR TITLE
Fix unresolved merge conflict in release workflow

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -191,11 +191,7 @@ jobs:
           path: pipe-fittings
 
       - name: Set up Docker
-<<<<<<< HEAD
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-=======
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
->>>>>>> origin/v1.5.x
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install Docker (if needed)
         run: |


### PR DESCRIPTION
The 2026-05-25 merge of `v1.5.x` into `develop` committed unresolved conflict markers (`<<<<<<< HEAD` block) around the `docker/setup-buildx-action` pin in `01-powerpipe-release.yaml`. The YAML has been unparseable since, so GitHub deregistered the workflow's `workflow_dispatch` trigger — dispatching the v1.5.3 release returns HTTP 422. PR #1102 carried the broken block from develop onto `v1.5.x`.

Resolves the block to the SHA-pinned v3.12.0 (`8d2750c`) chosen by the Actions-hardening pass. Verified the file now parses. A matching fix goes to `develop`, whose copy has the same committed markers and is what the workflow registration reads.

Blocks the v1.5.3 release dispatch.