### PR TITLE
Fix unresolved merge conflict in release workflow

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -191,11 +191,7 @@ jobs:
           path: pipe-fittings
 
       - name: Set up Docker
-<<<<<<< HEAD
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-=======
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
->>>>>>> origin/v1.5.x
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install Docker (if needed)
         run: |


### PR DESCRIPTION
Same fix as #1103, applied to `develop` — the branch the workflow registration reads. The 2026-05-25 merge of `v1.5.x` into `develop` committed unresolved conflict markers around the `docker/setup-buildx-action` pin in `01-powerpipe-release.yaml`; the file has been unparseable since, and GitHub deregistered the workflow's `workflow_dispatch` trigger (dispatch returns HTTP 422 — currently blocking the v1.5.3 release).

Resolves to the SHA-pinned v3.12.0 (`8d2750c`) chosen by the Actions-hardening pass. File verified to parse.