### PR TITLE
Disable the snapshot acceptance test block

### DIFF
--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -133,7 +133,9 @@ jobs:
           - "sp_files"
           - "var_resolution"
           - "params_and_args"
-          - "snapshot"
+          # Disabled: snapshot creates against turbot-ops/clitesting exceed the
+          # 60s gateway limit and return 504. Re-enable via #1106.
+          # - "snapshot"
           - "dashboard_parsing_validation"
           - "database_precedence"
           - "tag_filtering"


### PR DESCRIPTION
Removes the `snapshot` block from the acceptance-test matrix. Snapshot creates against `turbot-ops/clitesting` take longer than the API gateway's 60s limit and return `504 Gateway Timeout`, so the three tests in `snapshot.bats` fail on most runs.

Measured 2026-08-17, three consecutive publishes of a 23.6KB payload:

| attempt | status | time |
|---|---|---|
| 1 | 504 | 60.458s |
| 2 | 504 | 60.444s |
| 3 | 504 | 60.443s |

All three are the gateway ceiling, not a duration — the real create time is only known to be above 60s.

The entry is commented out rather than deleted so restoring it is a one-line change. The tests assert CSV/JSON/table output formatting in snapshot mode — as the file's own comment says, they are "not snapshot creation/upload" tests — so the coverage that goes dark is output formatting, not the publish path.

Leaving the block enabled also grows the workspace on every failure: a timed-out create still lands server-side, and the client never receives the snapshot ID it would need to delete the row.

Re-enabling is tracked by #1106.
