### PR TITLE
Do not crash the dashboard on an invalid grouping URL parameter

### DIFF
--- a/ui/dashboard/src/hooks/useGroupingConfig.ts
+++ b/ui/dashboard/src/hooks/useGroupingConfig.ts
@@ -9,15 +9,62 @@ const useGroupingConfig = (panelName?: string) => {
   const { panelsMap } = useDashboardState();
   const panel = panelName ? panelsMap[panelName] : undefined;
 
+  // Grouping arrives from the URL, so it is untrusted input: shareable links
+  // get hand-edited, truncated by chat clients, and outlive the mod they were
+  // built for. Anything unusable is DROPPED so the panel falls back to its
+  // default - previously each of these replaced the whole dashboard with an
+  // error boundary, leaving no way back except editing the URL by hand:
+  //
+  //   ?grouping={not-valid-json   -> "Expected property name or '}' in JSON..."
+  //   [{"type":"banana"}]         -> "Unknown group type banana"
+  //   {"panel":"nonsense"}        -> "n.filter is not a function"
+  //   [{"type":null}]             -> "Unknown group type null"
+  //
+  // The sibling `where` (filter) parameter already tolerates junk; this brings
+  // grouping into line with it.
   const allGroupings = useMemo(() => {
     const rawGroupings = searchParams.get("grouping");
-    if (rawGroupings) {
-      let parsedGroups: KeyValuePairs<DisplayGroup[]>;
-      parsedGroups = JSON.parse(rawGroupings);
-      return parsedGroups;
-    } else {
+    if (!rawGroupings) {
       return {};
     }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(rawGroupings);
+    } catch (e) {
+      return {};
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const knownTypes = new Set([
+      "benchmark",
+      "control",
+      "control_tag",
+      "detection",
+      "dimension",
+      "reason",
+      "resource",
+      "result",
+      "severity",
+      "status",
+    ]);
+
+    const safe: KeyValuePairs<DisplayGroup[]> = {};
+    for (const [panelKey, groups] of Object.entries(parsed)) {
+      if (!Array.isArray(groups)) {
+        continue;
+      }
+      const usable = (groups as any[]).filter(
+        (g) => !!g && typeof g === "object" && knownTypes.has(g.type),
+      ) as DisplayGroup[];
+      if (usable.length) {
+        safe[panelKey] = usable;
+      }
+    }
+    return safe;
   }, [searchParams]);
 
   const grouping = useMemo(() => {


### PR DESCRIPTION
# Do not crash the dashboard on an invalid grouping URL parameter

**Branch:** `fix-grouping-url-crash` → `develop` · 1 commit · `ui/dashboard/src/hooks/useGroupingConfig.ts`

## Problem

The `?grouping=` URL parameter is parsed with a bare `JSON.parse` and no shape
validation, so a malformed value takes down the whole dashboard with a white
screen. Four distinct fatal inputs:

| Input | Failure |
|---|---|
| `?grouping=not-json` | `SyntaxError` from `JSON.parse` |
| `?grouping="a string"` | `.filter is not a function` |
| `?grouping={"panel":"nonsense"}` | `.filter is not a function` |
| `?grouping={"panel":[{"type":null}]}` | `Unknown group type null` deep in tree building |

Anyone can be handed a crashing link — a truncated paste of a shared URL is
enough. The sibling `where=` (filter) parameter already tolerates junk; this
brings grouping into line with it.

## Fix

Wrap the parse in try/catch, validate the parsed shape (object of arrays), and
filter entries against the known grouping types. Unusable input degrades to the
default grouping instead of crashing.

## Testing

Exercised all four inputs above plus valid configs in a live dashboard; junk
now renders the default view, valid params behave as before.
