### PR TITLE
Build with Go 1.26.7 to remediate CVE-2026-39821 (GO-2026-5026)

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -226,7 +226,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Download Dashboard UI Assets Artifact

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -82,7 +82,7 @@ jobs:
        # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Build
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
           cache: false
 
       - name: Prepare for downloads

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/powerpipe
 
-go 1.26.5
+go 1.26.7
 
 //replace github.com/turbot/pipe-fittings/v2 => ../pipe-fittings
 


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.5 to 1.26.7 to remediate CVE-2026-39821 / GO-2026-5026 (CVSS 9.6).

## The vulnerability

`golang.org/x/net/idna`'s `ToASCII`/`ToUnicode` wrongly accept Punycode-encoded labels that decode to an ASCII-only label. `ToUnicode("xn--example-.com")` returns `"example.com"` instead of an error, so a caller that allowlists on the ASCII hostname can be bypassed by submitting the encoded spelling.

Fixed in Go 1.26.6, Go 1.25.13, Go 1.27.0-rc.3, and `golang.org/x/net` v0.55.0.

## Why this is toolchain-only

Powerpipe's direct `golang.org/x/net` dependency is already **v0.56.0**, which is past the fixed v0.55.0. That copy is not the problem.

The copy that is reachable here is the one **vendored into the Go standard library** and used by `net/http`. `govulncheck` attributes it to the stdlib, not to the module:

```
Vulnerability #12: GO-2026-5026
    Invoking failure to reject ASCII-only Punycode-encoded labels in
    golang.org/x/net/idna
  Standard library
    Found in: net/http@go1.26.5
    Fixed in: net/http@go1.26.6
```

So no dependency bump can fix it — only recompiling with a patched toolchain. This PR therefore touches **nothing but version pins**: no `go get -u`, no dependency changes, no `toolchain` directive, no code changes.

Targeting 1.26.7 rather than 1.26.6 because 1.26.7 is the current 1.26.x patch release and carries the same security content plus subsequent `net/http` bugfixes. Deliberately **not** jumping to 1.27.x — that would be a language-version change, not a patch.

## Changes

Five lines across four files:

| File | Change |
|---|---|
| `go.mod` | `go 1.26.5` -> `go 1.26.7` |
| `.github/workflows/01-powerpipe-release.yaml:229` | `go-version: "1.26.5"` -> `"1.26.7"` |
| `.github/workflows/10-test-lint.yaml:35` | `go-version: '1.26.5'` -> `'1.26.7'` |
| `.github/workflows/11-test-acceptance.yaml:85` | `go-version: '1.26.5'` -> `'1.26.7'` |
| `.github/workflows/11-test-acceptance.yaml:154` | `go-version: 1.26.5` -> `1.26.7` |

Each file's existing quoting style is preserved. I grepped the whole `.github/` tree and the rest of the repo for `1.26.5`; the only remaining hit is the historical `## v1.5.3` CHANGELOG entry, which is a record of a past release and is correctly left alone. I did not add a CHANGELOG entry since there is no unreleased section on `develop` — happy to add one if maintainers prefer.

## Verification

Built and scanned locally on darwin/arm64 with `govulncheck -mode=binary`, comparing the same source tree compiled by each toolchain.

**Before — `GOTOOLCHAIN=go1.26.5`:**
```
Vulnerability #12: GO-2026-5026
    Found in: net/http@go1.26.5
    Fixed in: net/http@go1.26.6
    Vulnerable symbols found:
      #1: http.Client.CloseIdleConnections
      #2: http.Client.Do
      #3: http.Client.Get
      #4: http.Client.Head
      #5: http.Client.Post
      Use '-show traces' to see the other 11 found symbols
Your code is affected by 12 vulnerabilities from 2 modules and the Go standard library.
```

**After — go1.26.7 (this branch):**
```
Your code is affected by 4 vulnerabilities from 2 modules.
```

GO-2026-5026 is gone, along with the other 7 stdlib findings that 1.26.6/1.26.7 also close. The 16 reachable `net/http` symbols confirm this was genuinely called code, not a theoretical import.

Also run:
- `go build ./...` — passes (exit 0)
- `go build -o powerpipe .` — passes, `go version -m` confirms `go1.26.7`

**What I did not verify:**
- `go vet ./...` exits 1, reporting 3 findings (a discarded `context.WithDeadline` cancel in `internal/db_client/db_client_execute.go:159` and two lock-copy findings in `internal/controlexecute/control_run.go`). I confirmed these are **pre-existing** by re-running vet on the unmodified base commit and getting byte-identical output. They are unrelated to this change and I have not attempted to fix them here.
- I did not run the acceptance test suite locally; CI on this PR should cover it.
- The remaining 4 findings after the bump are all third-party module vulns (3x `github.com/containerd/containerd`, 1x `go.opentelemetry.io/otel`), not stdlib. They are out of scope for this PR and unaffected by the toolchain.

## Downstream motivation

Turbot Pipes bundles Powerpipe into its `workspace` container image, where these are currently the only remaining CRITICAL findings. Verified 2026-08-31 by extracting the binaries from the built image `workspace@sha256:7f5ab7a3f39a` (v1.22.46-rc.1) and running `go version -m`:

```
/usr/local/bin/powerpipe   (Powerpipe v1.5.3)   go1.26.5   <- 1 hit
/opt/steampipe/steampipe-server (Pipes' own)    go1.26.7   <- CLEAN
```

Pipes already fixed its own binary (turbot/pipes#6801, Go 1.26.5 -> 1.26.7) and confirmed GO-2026-5026 went from CALLED to absent. But Pipes cannot fix Powerpipe itself — the CLI is installed from the Powerpipe release install script at image-build time, so the fix has to ship from a Powerpipe release.

This is a timing gap rather than neglect: Powerpipe v1.5.3 shipped 2026-08-10, built with go1.26.5, three days before go1.26.6 existed.

Companion PRs are being opened against `turbot/steampipe` and `turbot/steampipe-postgres-fdw` for the same reason. The FDW side also has an existing tracking issue: turbot/steampipe-postgres-fdw#695.

Please do not merge without maintainer review — flagging in particular whether 1.26.7 is the version you want to standardise on across the three repos.
