### PR TITLE
Backport: Build with Go 1.26.7 to remediate CVE-2026-39821 (GO-2026-5026)

### DIFF
--- a/.github/workflows/01-powerpipe-release.yaml
+++ b/.github/workflows/01-powerpipe-release.yaml
@@ -226,7 +226,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Download Dashboard UI Assets Artifact

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -82,7 +82,7 @@ jobs:
        # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: Build
@@ -149,7 +149,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
           cache: false
 
       - name: Prepare for downloads

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/powerpipe
 
-go 1.26.5
+go 1.26.7
 
 //replace github.com/turbot/pipe-fittings/v2 => ../pipe-fittings
 


### PR DESCRIPTION
Cherry-pick of 3aa3873 (#1113, merged to develop) onto v1.5.x so the fix ships in the next Powerpipe patch release. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
